### PR TITLE
28.0.14 RC1, 30.0.4 RC1, escape route for 28.0.13 installations

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -708,7 +708,7 @@ TbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk
 CrfaBIp6zQFLh+r/v0IjhQ==',
 			],
 		],
-		'28.0.13.0' => [
+		'28.0.14.0' => [
 			'100' => [
 				'latest' => '29.0.10',
 				'internalVersion' => '29.0.10.1',
@@ -726,34 +726,34 @@ QexpG3uO4JLIC3zb9EWw0g==',
 		],
 		'28' => [
 			'100' => [
-				'latest' => '28.0.13 RC1',
-				'internalVersion' => '28.0.13.0',
-				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-28.0.13rc1.zip',
+				'latest' => '28.0.14 RC1',
+				'internalVersion' => '28.0.14.0',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-28.0.14rc1.zip',
 				'web' => 'https://docs.nextcloud.com/server/28/admin_manual/maintenance/upgrade.html',
-				'eol' => false,
+				'eol' => true,
 				'minPHPVersion' => '8.0',
-				'signature' => 'F3+gp9NaTJ2RTKYaE6VIMCaN7R76WZJRxmEITlBKosyxVWvf4MHmwvfCAOWh/1JL
-jhu2wqmE6bLC/IXQlrQAN9ny1UtLWMCzbZP1fNjUme7mMSSizEDs3+srXy11BfEj
-WU30XsuOToB29hVPON08TyxEcuJ6dyEFVRBVm0za/IcT6f5U1YZHoIxsXlne4Ja7
-62Yv48d+qBosMxUJbxsKazYefwvPDMLFahhHTt4xm6Jzr/QskOTBbOtIt3SRQAbk
-2h1hGqb2NywMahZx7rhQCxhbB94A8GVkd7hyE+FOePugTbJ4TB3M6G7g/yQH4lse
-qDhKDAucVLoSatvDk75plw==',
+				'signature' => 'amIJRR1sRsQvBOcSz6xgH+8m48PQidOIggk8OmuHXSTooazAzbR7/1aPBA+v3MUA
+gkDQFSsw+pD6CDtvIWpjqSdVYnZ2oMnacYUA5buszbO25cg5rH7Zw8SIqMbWwEUr
+nJJjHQ1dLl1nUeFpzwp5YwFst6WJmdmtgXf4a5MTcwEbsX9VIkaTNS0Yb1yBIYfN
+3aAHUtFNEvrcV1T74Cj3p3nff4xPpJ/GiZhrOiCG0bU29vffw3WtaPPyrKzIxuXE
+cs0LWF2xWZSQzKincvBuPo+HnFzz2FIzdq5gmkFMWnjgnT+JBqym/eQnjh1xYd0x
+56A+H6/K8zkPkHY8TjCD7w==',
 			],
 		],
 		'27.1.11.3' => [
 			'100' => [
-				'latest' => '28.0.13 RC1',
-				'internalVersion' => '28.0.13.0',
-				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-28.0.13rc1.zip',
+				'latest' => '28.0.14 RC1',
+				'internalVersion' => '28.0.14.0',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-28.0.14rc1.zip',
 				'web' => 'https://docs.nextcloud.com/server/28/admin_manual/maintenance/upgrade.html',
-				'eol' => false,
+				'eol' => true,
 				'minPHPVersion' => '8.0',
-				'signature' => 'F3+gp9NaTJ2RTKYaE6VIMCaN7R76WZJRxmEITlBKosyxVWvf4MHmwvfCAOWh/1JL
-jhu2wqmE6bLC/IXQlrQAN9ny1UtLWMCzbZP1fNjUme7mMSSizEDs3+srXy11BfEj
-WU30XsuOToB29hVPON08TyxEcuJ6dyEFVRBVm0za/IcT6f5U1YZHoIxsXlne4Ja7
-62Yv48d+qBosMxUJbxsKazYefwvPDMLFahhHTt4xm6Jzr/QskOTBbOtIt3SRQAbk
-2h1hGqb2NywMahZx7rhQCxhbB94A8GVkd7hyE+FOePugTbJ4TB3M6G7g/yQH4lse
-qDhKDAucVLoSatvDk75plw==',
+				'signature' => 'amIJRR1sRsQvBOcSz6xgH+8m48PQidOIggk8OmuHXSTooazAzbR7/1aPBA+v3MUA
+gkDQFSsw+pD6CDtvIWpjqSdVYnZ2oMnacYUA5buszbO25cg5rH7Zw8SIqMbWwEUr
+nJJjHQ1dLl1nUeFpzwp5YwFst6WJmdmtgXf4a5MTcwEbsX9VIkaTNS0Yb1yBIYfN
+3aAHUtFNEvrcV1T74Cj3p3nff4xPpJ/GiZhrOiCG0bU29vffw3WtaPPyrKzIxuXE
+cs0LWF2xWZSQzKincvBuPo+HnFzz2FIzdq5gmkFMWnjgnT+JBqym/eQnjh1xYd0x
+56A+H6/K8zkPkHY8TjCD7w==',
 			],
 		],
 	],

--- a/config/config.php
+++ b/config/config.php
@@ -678,18 +678,34 @@ vbaIJ8CiZnKdMBDAdXAVMA==',
 	'beta' => [
 		'30' => [
 			'100' => [
-				'latest' => '30.0.3 RC2',
-				'internalVersion' => '30.0.3.1',
-				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-30.0.3rc2.zip',
+				'latest' => '30.0.4 RC1',
+				'internalVersion' => '30.0.4.0',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-30.0.4rc1.zip',
 				'web' => 'https://docs.nextcloud.com/server/30/admin_manual/maintenance/upgrade.html',
 				'eol' => false,
 				'minPHPVersion' => '8.1',
-				'signature' => 'u395gCuNyuCNATMa7eiN35A6rjvH4JGfYo3T5xX/zRBLHNa/UF9U5E60k7yFDspc
-DVYaL3a2CRIWlqTxNeR8jM9SLt8+ME2JVv128n/qe3qxLeIPXAl9UwmzXP3lAmFC
-8IMSiVL73qYIKZtuByAFyarQo2B0tYBKpmvJEAm6QQL6iXoiMQUO3J0Vk7BAA79s
-tW0UA6T5nA4Q8hgF3svvXWfZ5C+4hqbqA+A5s4gePB6tVzBK7ORHGul/znzTpmnm
-Z7W05b1cJl/4FzT/g20xM9jwnD6KCJW1GGU3ecLeb+UG5T6SBe50ZmIXSJMUrcFi
-4i9NVOoA5tGI1JuU6QnuGg==',
+				'signature' => 'C2mCIM9juoPX3qhzDqAXngJJRJmTGNOQIC5obyRsQlWH6xbvD4NbxiMiHvAgUtJm
+u5zGE1y6sG1N85GYUsmHoeawsMkCHXRuc2GWcJ/IkqSicjwPZh3uTCkGVr5uvI3E
+31DWyFUniYrtXBlS80UtMRlKW+wcRn1Pi4IPhKCadXBE6ABZoZ/DciduV5kiJVaM
+TbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk
+6ReCUIzv7/oSpN4E1Jd15bEzG9q3U+sBfcK0GMWahPkOwjz7F28r/BzRgbJusFaA
+CrfaBIp6zQFLh+r/v0IjhQ==',
+			],
+		],
+		'29.0.10.1' => [
+			'100' => [
+				'latest' => '30.0.4 RC1',
+				'internalVersion' => '30.0.4.0',
+				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-30.0.4rc1.zip',
+				'web' => 'https://docs.nextcloud.com/server/30/admin_manual/maintenance/upgrade.html',
+				'eol' => false,
+				'minPHPVersion' => '8.1',
+				'signature' => 'C2mCIM9juoPX3qhzDqAXngJJRJmTGNOQIC5obyRsQlWH6xbvD4NbxiMiHvAgUtJm
+u5zGE1y6sG1N85GYUsmHoeawsMkCHXRuc2GWcJ/IkqSicjwPZh3uTCkGVr5uvI3E
+31DWyFUniYrtXBlS80UtMRlKW+wcRn1Pi4IPhKCadXBE6ABZoZ/DciduV5kiJVaM
+TbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk
+6ReCUIzv7/oSpN4E1Jd15bEzG9q3U+sBfcK0GMWahPkOwjz7F28r/BzRgbJusFaA
+CrfaBIp6zQFLh+r/v0IjhQ==',
 			],
 		],
 		'28.0.13.0' => [

--- a/config/config.php
+++ b/config/config.php
@@ -49,6 +49,22 @@ egpWI7BoU2Qke/uqkNhgjyMg0wbYLYLGzKOTGhzWrs9Sy0LhnwFG6jE+m3ZYk8tr
 QexpG3uO4JLIC3zb9EWw0g==',
 			],
 		],
+		'28.0.13.1' => [
+			'100' => [
+				'latest' => '29.0.10',
+				'internalVersion' => '29.0.10.1',
+				'downloadUrl' => 'https://download.nextcloud.com/server/releases/nextcloud-29.0.10.zip',
+				'web' => 'https://docs.nextcloud.com/server/29/admin_manual/maintenance/upgrade.html',
+				'eol' => false,
+				'minPHPVersion' => '8.0',
+				'signature' => 'y1EjwPsIOi7csy5i7eINb5KWvtOfdQTdBdofwHpk1HlzOGWwoCosM+1dShJbwzaR
+Zsi2AlOL/c7CeHY8aH6smcJaqAGhlQityVGs0zKYlpMR5afglk0b+2+Hb9GR1T/M
+8eb6qNsjO3KgxUe8ZBE8JZ32INpRqylQb2zvAKFMHzbz06Nj+574arnMY0o3LwR6
+o+wGx3e25/i5ybO+pLoqsEsoYgkl/DaSpcRor5tEWm7qiPtk8+aT2s/phuMftioQ
+egpWI7BoU2Qke/uqkNhgjyMg0wbYLYLGzKOTGhzWrs9Sy0LhnwFG6jE+m3ZYk8tr
+QexpG3uO4JLIC3zb9EWw0g==',
+			],
+		],
 		'28.0.12.2' => [
 			'100' => [
 				'latest' => '29.0.10',
@@ -709,6 +725,22 @@ CrfaBIp6zQFLh+r/v0IjhQ==',
 			],
 		],
 		'28.0.14.0' => [
+			'100' => [
+				'latest' => '29.0.10',
+				'internalVersion' => '29.0.10.1',
+				'downloadUrl' => 'https://download.nextcloud.com/server/releases/nextcloud-29.0.10.zip',
+				'web' => 'https://docs.nextcloud.com/server/29/admin_manual/maintenance/upgrade.html',
+				'eol' => false,
+				'minPHPVersion' => '8.0',
+				'signature' => 'y1EjwPsIOi7csy5i7eINb5KWvtOfdQTdBdofwHpk1HlzOGWwoCosM+1dShJbwzaR
+Zsi2AlOL/c7CeHY8aH6smcJaqAGhlQityVGs0zKYlpMR5afglk0b+2+Hb9GR1T/M
+8eb6qNsjO3KgxUe8ZBE8JZ32INpRqylQb2zvAKFMHzbz06Nj+574arnMY0o3LwR6
+o+wGx3e25/i5ybO+pLoqsEsoYgkl/DaSpcRor5tEWm7qiPtk8+aT2s/phuMftioQ
+egpWI7BoU2Qke/uqkNhgjyMg0wbYLYLGzKOTGhzWrs9Sy0LhnwFG6jE+m3ZYk8tr
+QexpG3uO4JLIC3zb9EWw0g==',
+			],
+		],
+		'28.0.13.1' => [
 			'100' => [
 				'latest' => '29.0.10',
 				'internalVersion' => '29.0.10.1',

--- a/config/releases.json
+++ b/config/releases.json
@@ -93,8 +93,8 @@
         "internalVersion": "30.0.2.2",
         "signature": "uwSmmFxroTIbFhaCPq9EJTiEzMB8/v5sYvTbEEZp0aBjxN+64rkIgWZmqtGt0l/z3wZQOh1nGnZtwE2PxWDrv1qSEB13RVd6yH0RKCHi9AYOqwIDuw0YO2Z+hqLC8jCQyeDiP9FRcKx2IwmGoEhmcnS7A7N+36Bu+eo5bo5hFfZ6aHXol3e1ybmyiotkOS2Xk0ea4TaXu/DhFep6LeOs02D3md8axknwpeKppJcNzXaGt6nT3zbYEPrI+qjxIrbBMg6LhJwRlQBSQ7oXcI8AU+dVIiMvCuv8qyqzfBfjVu16yBwY5k37Q4HK2dQWxky8h9nvBLY36Nn47IEvKwg+bw=="
     },
-    "30.0.3 RC2": {
-        "internalVersion": "30.0.3.1",
-        "signature": "u395gCuNyuCNATMa7eiN35A6rjvH4JGfYo3T5xX/zRBLHNa/UF9U5E60k7yFDspcDVYaL3a2CRIWlqTxNeR8jM9SLt8+ME2JVv128n/qe3qxLeIPXAl9UwmzXP3lAmFC8IMSiVL73qYIKZtuByAFyarQo2B0tYBKpmvJEAm6QQL6iXoiMQUO3J0Vk7BAA79stW0UA6T5nA4Q8hgF3svvXWfZ5C+4hqbqA+A5s4gePB6tVzBK7ORHGul/znzTpmnmZ7W05b1cJl/4FzT/g20xM9jwnD6KCJW1GGU3ecLeb+UG5T6SBe50ZmIXSJMUrcFi4i9NVOoA5tGI1JuU6QnuGg=="
-    }
+	"30.0.4 RC1": {
+		"internalVersion": "30.0.4.0",
+		"signature": "C2mCIM9juoPX3qhzDqAXngJJRJmTGNOQIC5obyRsQlWH6xbvD4NbxiMiHvAgUtJmu5zGE1y6sG1N85GYUsmHoeawsMkCHXRuc2GWcJ/IkqSicjwPZh3uTCkGVr5uvI3E31DWyFUniYrtXBlS80UtMRlKW+wcRn1Pi4IPhKCadXBE6ABZoZ/DciduV5kiJVaMTbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk6ReCUIzv7/oSpN4E1Jd15bEzG9q3U+sBfcK0GMWahPkOwjz7F28r/BzRgbJusFaACrfaBIp6zQFLh+r/v0IjhQ=="
+	}
 }

--- a/config/releases.json
+++ b/config/releases.json
@@ -81,10 +81,10 @@
         "internalVersion": "28.0.12.2",
         "signature": "wy9qrzRm5KLnr2xpHXfSi2S4ZHEiNTSOKpuHFHrfoNJFX+llNzDkyvSBAxDxkDLRuRY5LR2y8NMbGKzBSSeg1mlR8yuFrP058zxv7izT2aFW6qSyAqEvRiw5r5FAuxdsME1BqrIavGzOzObzExtN2qrh7OdBDw6c7bEuouftA0fR1RnP3Rcjm+fKJbEFWZHQ01+IL5xHLGqDqT6kWCHYYQRS1+NUcyG2EEjMLk+U1supQKuCynF8z9D1J4bS1mXXvvXhZo/vg9NIBpAgzOmz+71HTm11nB1DiFOTi6zdkNm50LbWIFyyhE82RHCCtru/AJPeeesagNpLE0n/XjGb3Q=="
     },
-    "28.0.13 RC1": {
-        "internalVersion": "28.0.13.0",
-        "signature": "F3+gp9NaTJ2RTKYaE6VIMCaN7R76WZJRxmEITlBKosyxVWvf4MHmwvfCAOWh/1JLjhu2wqmE6bLC/IXQlrQAN9ny1UtLWMCzbZP1fNjUme7mMSSizEDs3+srXy11BfEjWU30XsuOToB29hVPON08TyxEcuJ6dyEFVRBVm0za/IcT6f5U1YZHoIxsXlne4Ja762Yv48d+qBosMxUJbxsKazYefwvPDMLFahhHTt4xm6Jzr/QskOTBbOtIt3SRQAbk2h1hGqb2NywMahZx7rhQCxhbB94A8GVkd7hyE+FOePugTbJ4TB3M6G7g/yQH4lseqDhKDAucVLoSatvDk75plw=="
-    },
+	"28.0.14 RC1": {
+		"internalVersion": "28.0.14.0",
+		"signature": "amIJRR1sRsQvBOcSz6xgH+8m48PQidOIggk8OmuHXSTooazAzbR7/1aPBA+v3MUAgkDQFSsw+pD6CDtvIWpjqSdVYnZ2oMnacYUA5buszbO25cg5rH7Zw8SIqMbWwEUrnJJjHQ1dLl1nUeFpzwp5YwFst6WJmdmtgXf4a5MTcwEbsX9VIkaTNS0Yb1yBIYfN3aAHUtFNEvrcV1T74Cj3p3nff4xPpJ/GiZhrOiCG0bU29vffw3WtaPPyrKzIxuXEcs0LWF2xWZSQzKincvBuPo+HnFzz2FIzdq5gmkFMWnjgnT+JBqym/eQnjh1xYd0x56A+H6/K8zkPkHY8TjCD7w=="
+	},
 	"29.0.10": {
 		"internalVersion": "29.0.10.1",
 		"signature": "y1EjwPsIOi7csy5i7eINb5KWvtOfdQTdBdofwHpk1HlzOGWwoCosM+1dShJbwzaRZsi2AlOL/c7CeHY8aH6smcJaqAGhlQityVGs0zKYlpMR5afglk0b+2+Hb9GR1T/M8eb6qNsjO3KgxUe8ZBE8JZ32INpRqylQb2zvAKFMHzbz06Nj+574arnMY0o3LwR6o+wGx3e25/i5ybO+pLoqsEsoYgkl/DaSpcRor5tEWm7qiPtk8+aT2s/phuMftioQegpWI7BoU2Qke/uqkNhgjyMg0wbYLYLGzKOTGhzWrs9Sy0LhnwFG6jE+m3ZYk8trQexpG3uO4JLIC3zb9EWw0g=="

--- a/tests/integration/features/beta.feature
+++ b/tests/integration/features/beta.feature
@@ -471,18 +471,18 @@ Feature: Testing the update scenario of beta releases
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "28.0.13.0" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-28.0.13rc1.zip"
+    And Update to version "28.0.14.0" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-28.0.14rc1.zip"
     And URL to documentation is "https://docs.nextcloud.com/server/28/admin_manual/maintenance/upgrade.html"
-    And EOL is set to "0"
+    And EOL is set to "1"
     And The signature is
     """
-    F3+gp9NaTJ2RTKYaE6VIMCaN7R76WZJRxmEITlBKosyxVWvf4MHmwvfCAOWh/1JL
-    jhu2wqmE6bLC/IXQlrQAN9ny1UtLWMCzbZP1fNjUme7mMSSizEDs3+srXy11BfEj
-    WU30XsuOToB29hVPON08TyxEcuJ6dyEFVRBVm0za/IcT6f5U1YZHoIxsXlne4Ja7
-    62Yv48d+qBosMxUJbxsKazYefwvPDMLFahhHTt4xm6Jzr/QskOTBbOtIt3SRQAbk
-    2h1hGqb2NywMahZx7rhQCxhbB94A8GVkd7hyE+FOePugTbJ4TB3M6G7g/yQH4lse
-    qDhKDAucVLoSatvDk75plw==
+    amIJRR1sRsQvBOcSz6xgH+8m48PQidOIggk8OmuHXSTooazAzbR7/1aPBA+v3MUA
+    gkDQFSsw+pD6CDtvIWpjqSdVYnZ2oMnacYUA5buszbO25cg5rH7Zw8SIqMbWwEUr
+    nJJjHQ1dLl1nUeFpzwp5YwFst6WJmdmtgXf4a5MTcwEbsX9VIkaTNS0Yb1yBIYfN
+    3aAHUtFNEvrcV1T74Cj3p3nff4xPpJ/GiZhrOiCG0bU29vffw3WtaPPyrKzIxuXE
+    cs0LWF2xWZSQzKincvBuPo+HnFzz2FIzdq5gmkFMWnjgnT+JBqym/eQnjh1xYd0x
+    56A+H6/K8zkPkHY8TjCD7w==
     """
 
   Scenario: Updating Nextcloud 28 on the beta channel
@@ -492,23 +492,23 @@ Feature: Testing the update scenario of beta releases
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "28.0.13.0" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-28.0.13rc1.zip"
+    And Update to version "28.0.14.0" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-28.0.14rc1.zip"
     And URL to documentation is "https://docs.nextcloud.com/server/28/admin_manual/maintenance/upgrade.html"
-    And EOL is set to "0"
+    And EOL is set to "1"
     And The signature is
     """
-    F3+gp9NaTJ2RTKYaE6VIMCaN7R76WZJRxmEITlBKosyxVWvf4MHmwvfCAOWh/1JL
-    jhu2wqmE6bLC/IXQlrQAN9ny1UtLWMCzbZP1fNjUme7mMSSizEDs3+srXy11BfEj
-    WU30XsuOToB29hVPON08TyxEcuJ6dyEFVRBVm0za/IcT6f5U1YZHoIxsXlne4Ja7
-    62Yv48d+qBosMxUJbxsKazYefwvPDMLFahhHTt4xm6Jzr/QskOTBbOtIt3SRQAbk
-    2h1hGqb2NywMahZx7rhQCxhbB94A8GVkd7hyE+FOePugTbJ4TB3M6G7g/yQH4lse
-    qDhKDAucVLoSatvDk75plw==
+    amIJRR1sRsQvBOcSz6xgH+8m48PQidOIggk8OmuHXSTooazAzbR7/1aPBA+v3MUA
+    gkDQFSsw+pD6CDtvIWpjqSdVYnZ2oMnacYUA5buszbO25cg5rH7Zw8SIqMbWwEUr
+    nJJjHQ1dLl1nUeFpzwp5YwFst6WJmdmtgXf4a5MTcwEbsX9VIkaTNS0Yb1yBIYfN
+    3aAHUtFNEvrcV1T74Cj3p3nff4xPpJ/GiZhrOiCG0bU29vffw3WtaPPyrKzIxuXE
+    cs0LWF2xWZSQzKincvBuPo+HnFzz2FIzdq5gmkFMWnjgnT+JBqym/eQnjh1xYd0x
+    56A+H6/K8zkPkHY8TjCD7w==
     """
 
   Scenario: Updating latest Nextcloud 28 on the beta channel
     Given There is a release with channel "beta"
-    And The received version is "28.0.13.0"
+    And The received version is "28.0.14.0"
     And The received PHP version is "8.1.0"
     And the installation mtime is "11"
     When The request is sent

--- a/tests/integration/features/beta.feature
+++ b/tests/integration/features/beta.feature
@@ -555,18 +555,18 @@ Feature: Testing the update scenario of beta releases
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "30.0.3.1" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-30.0.3rc2.zip"
+    And Update to version "30.0.4.0" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-30.0.4rc1.zip"
     And URL to documentation is "https://docs.nextcloud.com/server/30/admin_manual/maintenance/upgrade.html"
     And EOL is set to "0"
     And The signature is
     """
-    u395gCuNyuCNATMa7eiN35A6rjvH4JGfYo3T5xX/zRBLHNa/UF9U5E60k7yFDspc
-    DVYaL3a2CRIWlqTxNeR8jM9SLt8+ME2JVv128n/qe3qxLeIPXAl9UwmzXP3lAmFC
-    8IMSiVL73qYIKZtuByAFyarQo2B0tYBKpmvJEAm6QQL6iXoiMQUO3J0Vk7BAA79s
-    tW0UA6T5nA4Q8hgF3svvXWfZ5C+4hqbqA+A5s4gePB6tVzBK7ORHGul/znzTpmnm
-    Z7W05b1cJl/4FzT/g20xM9jwnD6KCJW1GGU3ecLeb+UG5T6SBe50ZmIXSJMUrcFi
-    4i9NVOoA5tGI1JuU6QnuGg==
+    C2mCIM9juoPX3qhzDqAXngJJRJmTGNOQIC5obyRsQlWH6xbvD4NbxiMiHvAgUtJm
+    u5zGE1y6sG1N85GYUsmHoeawsMkCHXRuc2GWcJ/IkqSicjwPZh3uTCkGVr5uvI3E
+    31DWyFUniYrtXBlS80UtMRlKW+wcRn1Pi4IPhKCadXBE6ABZoZ/DciduV5kiJVaM
+    TbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk
+    6ReCUIzv7/oSpN4E1Jd15bEzG9q3U+sBfcK0GMWahPkOwjz7F28r/BzRgbJusFaA
+    CrfaBIp6zQFLh+r/v0IjhQ==
     """
 
   Scenario: Updating Nextcloud 30 on the beta channel
@@ -576,37 +576,37 @@ Feature: Testing the update scenario of beta releases
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "30.0.3.1" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-30.0.3rc2.zip"
+    And Update to version "30.0.4.0" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-30.0.4rc1.zip"
     And URL to documentation is "https://docs.nextcloud.com/server/30/admin_manual/maintenance/upgrade.html"
     And EOL is set to "0"
     And The signature is
     """
-    u395gCuNyuCNATMa7eiN35A6rjvH4JGfYo3T5xX/zRBLHNa/UF9U5E60k7yFDspc
-    DVYaL3a2CRIWlqTxNeR8jM9SLt8+ME2JVv128n/qe3qxLeIPXAl9UwmzXP3lAmFC
-    8IMSiVL73qYIKZtuByAFyarQo2B0tYBKpmvJEAm6QQL6iXoiMQUO3J0Vk7BAA79s
-    tW0UA6T5nA4Q8hgF3svvXWfZ5C+4hqbqA+A5s4gePB6tVzBK7ORHGul/znzTpmnm
-    Z7W05b1cJl/4FzT/g20xM9jwnD6KCJW1GGU3ecLeb+UG5T6SBe50ZmIXSJMUrcFi
-    4i9NVOoA5tGI1JuU6QnuGg==
+    C2mCIM9juoPX3qhzDqAXngJJRJmTGNOQIC5obyRsQlWH6xbvD4NbxiMiHvAgUtJm
+    u5zGE1y6sG1N85GYUsmHoeawsMkCHXRuc2GWcJ/IkqSicjwPZh3uTCkGVr5uvI3E
+    31DWyFUniYrtXBlS80UtMRlKW+wcRn1Pi4IPhKCadXBE6ABZoZ/DciduV5kiJVaM
+    TbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk
+    6ReCUIzv7/oSpN4E1Jd15bEzG9q3U+sBfcK0GMWahPkOwjz7F28r/BzRgbJusFaA
+    CrfaBIp6zQFLh+r/v0IjhQ==
     """
 
   Scenario: Updating latest Nextcloud 30 on the beta channel
     Given There is a release with channel "beta"
-    And The received version is "30.0.2.1"
+    And The received version is "30.0.3.2"
     And The received PHP version is "8.1.0"
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "30.0.3.1" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-30.0.3rc2.zip"
+    And Update to version "30.0.4.0" is available
+    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-30.0.4rc1.zip"
     And URL to documentation is "https://docs.nextcloud.com/server/30/admin_manual/maintenance/upgrade.html"
     And EOL is set to "0"
     And The signature is
     """
-    u395gCuNyuCNATMa7eiN35A6rjvH4JGfYo3T5xX/zRBLHNa/UF9U5E60k7yFDspc
-    DVYaL3a2CRIWlqTxNeR8jM9SLt8+ME2JVv128n/qe3qxLeIPXAl9UwmzXP3lAmFC
-    8IMSiVL73qYIKZtuByAFyarQo2B0tYBKpmvJEAm6QQL6iXoiMQUO3J0Vk7BAA79s
-    tW0UA6T5nA4Q8hgF3svvXWfZ5C+4hqbqA+A5s4gePB6tVzBK7ORHGul/znzTpmnm
-    Z7W05b1cJl/4FzT/g20xM9jwnD6KCJW1GGU3ecLeb+UG5T6SBe50ZmIXSJMUrcFi
-    4i9NVOoA5tGI1JuU6QnuGg==
+    C2mCIM9juoPX3qhzDqAXngJJRJmTGNOQIC5obyRsQlWH6xbvD4NbxiMiHvAgUtJm
+    u5zGE1y6sG1N85GYUsmHoeawsMkCHXRuc2GWcJ/IkqSicjwPZh3uTCkGVr5uvI3E
+    31DWyFUniYrtXBlS80UtMRlKW+wcRn1Pi4IPhKCadXBE6ABZoZ/DciduV5kiJVaM
+    TbU4LTjFVbzB2Iq9AC6/+fbUVCbxtVNuyj7sZOZ+2VFh+pVU5PlgSmYR5DxleVFk
+    6ReCUIzv7/oSpN4E1Jd15bEzG9q3U+sBfcK0GMWahPkOwjz7F28r/BzRgbJusFaA
+    CrfaBIp6zQFLh+r/v0IjhQ==
     """


### PR DESCRIPTION
I expect the config.php test to complain as I added an additional route for installations that already upgraded to 28.0.13