### PR TITLE
fix(ci): skip no-op self-upgrade for a major's first stable release

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -106,6 +106,16 @@ jobs:
           echo "BASE_VERSION=$VERSION" >> $GITHUB_ENV
           echo "BASE_VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV
 
+          # When a new major's first stable release lands, the bare-major entry
+          # (e.g. base "34") normalizes to X.0.0, which equals the target latest.
+          # That is a no-op self-upgrade the updater rightfully refuses, so skip it.
+          PREFIX="${{ matrix.config.latest }}"
+          PREFIX="${PREFIX%% *}"  # remove everything after the first space (enterprise)
+          if [ "$VERSION_STRING" = "$PREFIX" ]; then
+            echo "::notice::Base $VERSION_STRING equals target $PREFIX — skipping no-op self-upgrade"
+            echo "SKIP_UPGRADE=true" >> $GITHUB_ENV
+          fi
+
       - name: Setup nextcloud ${{ env.BASE_VERSION_STRING }} (${{ env.BASE_VERSION }})
         run: |
           cd nextcloud
@@ -113,7 +123,7 @@ jobs:
           php occ maintenance:install --verbose --admin-user admin --admin-pass admin
 
       - name: Fetch upgrade
-        if: matrix.mode == 'manual'
+        if: matrix.mode == 'manual' && env.SKIP_UPGRADE != 'true'
         run: |
           mv nextcloud nextcloud.old
           wget --quiet ${{ matrix.config.downloadUrl }} -O nextcloud-update.zip
@@ -125,19 +135,19 @@ jobs:
           echo "TARGET_VERSION_STRING=$VERSION_STRING" >> $GITHUB_ENV
 
       - name: Copy necessary files
-        if: matrix.mode == 'manual'
+        if: matrix.mode == 'manual' && env.SKIP_UPGRADE != 'true'
         run: |
           mv nextcloud.old/config/config.php nextcloud/config/config.php
           mv nextcloud.old/data nextcloud/data
 
       - name: Perform upgrade to ${{ env.TARGET_VERSION_STRING }} (${{ env.TARGET_VERSION }})
-        if: matrix.mode == 'manual'
+        if: matrix.mode == 'manual' && env.SKIP_UPGRADE != 'true'
         run: |
           cd nextcloud
           php occ upgrade -v
 
       - name: Use updater
-        if: matrix.mode == 'updater'
+        if: matrix.mode == 'updater' && env.SKIP_UPGRADE != 'true'
         run: |
           cd nextcloud
           BASE="${{ matrix.config.base }}"
@@ -154,11 +164,13 @@ jobs:
           php updater/updater.phar --url ${{ matrix.config.downloadUrl }} --no-backup --no-interaction --no-verify -vvv
 
       - name: Integrity check
+        if: env.SKIP_UPGRADE != 'true'
         run: |
           cd nextcloud
           php occ integrity:check-core
 
       - name: Verify final Nextcloud version
+        if: env.SKIP_UPGRADE != 'true'
         run: |
           cd nextcloud
           VERSION=$(php occ --output=json status | jq -r .version)

--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,86 @@
 <?php
 return [
 	'stable' => [
+		'34' => [
+			'100' => [
+				'latest' => '34.0.0',
+				'internalVersion' => '34.0.0.12',
+				'downloadUrl' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip',
+				'downloads' => [
+					'bz2' => [
+						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2',
+						'1' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2',
+					],
+					'zip' => [
+						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip',
+						'1' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip',
+					],
+				],
+				'web' => 'https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html',
+				'eol' => '',
+				'minPHPVersion' => '8.2',
+				'signature' => 'wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+tROcuuq4A6jcCjhT178clw==',
+				'signatures' => [
+					'bz2' => 'Xcmsalf2JFOERdm+glnMIgwKJP7cu3CK1Kt9doIIELl+0/W5nJp98ZDs29m445/e
+TZPhjOBDcu1xw/AblUNeU0eAyNQflMhtT82Zoe4eKiQ14/Oerh+M+/t7O3dmqbDw
+W+2QAteOHSeKcWb+m5KSWEWW81M+OiXPCauLnYVP6oG66Dn2Wqt6dOAjwLpn6z02
+uGWTZy+4C0Uok/kY+xtmsy/uiIiZvvuVZFdGGh9eKhinr8PbCyvON1pFmb0FjCi3
+Ybg2VWxS+M9hm9DErFQcEHuf2O8QRmWsUdTC8+Bghp0pMHYju8ftKcRowQkBu8c/
+7RQFy55zpZaPEo6+0weB/A==',
+					'zip' => 'wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+tROcuuq4A6jcCjhT178clw==',
+				],
+			],
+		],
+		'33.0.5.1' => [
+			'30' => [
+				'latest' => '34.0.0',
+				'internalVersion' => '34.0.0.12',
+				'downloadUrl' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip',
+				'downloads' => [
+					'bz2' => [
+						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2',
+						'1' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2',
+					],
+					'zip' => [
+						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip',
+						'1' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip',
+					],
+				],
+				'web' => 'https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html',
+				'eol' => '',
+				'minPHPVersion' => '8.2',
+				'signature' => 'wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+tROcuuq4A6jcCjhT178clw==',
+				'signatures' => [
+					'bz2' => 'Xcmsalf2JFOERdm+glnMIgwKJP7cu3CK1Kt9doIIELl+0/W5nJp98ZDs29m445/e
+TZPhjOBDcu1xw/AblUNeU0eAyNQflMhtT82Zoe4eKiQ14/Oerh+M+/t7O3dmqbDw
+W+2QAteOHSeKcWb+m5KSWEWW81M+OiXPCauLnYVP6oG66Dn2Wqt6dOAjwLpn6z02
+uGWTZy+4C0Uok/kY+xtmsy/uiIiZvvuVZFdGGh9eKhinr8PbCyvON1pFmb0FjCi3
+Ybg2VWxS+M9hm9DErFQcEHuf2O8QRmWsUdTC8+Bghp0pMHYju8ftKcRowQkBu8c/
+7RQFy55zpZaPEo6+0weB/A==',
+					'zip' => 'wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+tROcuuq4A6jcCjhT178clw==',
+				],
+			],
+		],
 		'33' => [
 			'100' => [
 				'latest' => '33.0.5',
@@ -1605,83 +1685,43 @@ vbaIJ8CiZnKdMBDAdXAVMA==',
 		],
 	],
 	'beta' => [
-		'34' => [
-			'100' => [
-				'latest' => '34.0.0 RC5',
-				'internalVersion' => '34.0.0.11',
-				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip',
-				'downloads' => [
-					'bz2' => [
-						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.tar.bz2',
-						'1' => 'https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.tar.bz2',
-					],
-					'zip' => [
-						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.zip',
-						'1' => 'https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip',
-					],
-				],
-				'web' => 'https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html',
-				'eol' => '',
-				'minPHPVersion' => '8.2',
-				'signature' => 'ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1
-/VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid
-2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB
-3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA
-4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrIS
-ILUlWHKNuhVMDCWn0BkbFw==',
-				'signatures' => [
-					'bz2' => 'W/tiziEGARA4TVuHMOa51iu9HcPQkbM+x8NkwHUc1WET+jYEzhUZY0xmL811U7H8
-3mbdabIb/5acIpVma+QNJE65kiNrkYPdPD1mOpHHtv+ORyH+KAhuLQ668fYNysvy
-KVapOcEkQHtLFVM9vT/wUqnVbHgFd0efgSz9hPzrS5Jm+MoeRvIGfEB54WPUgI0d
-HtB6/kPdL0vNMU2zEgZksDg0vhqy2UyNqXR5pcjbhRla4n5W4iYWYlMKXMHb30N5
-1fvp5YwioA6Ll/2/tT1MHEdpKOlKRJ61kPAOt+kcRZHtjI16UezC+DE0b6gDXxAA
-yfBdiRBgE/aekFAIWtOdfQ==',
-					'zip' => 'ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1
-/VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid
-2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB
-3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA
-4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrIS
-ILUlWHKNuhVMDCWn0BkbFw==',
-				],
-			],
-		],
 		'33.0.5.1' => [
 			'100' => [
-				'latest' => '34.0.0 RC5',
-				'internalVersion' => '34.0.0.11',
-				'downloadUrl' => 'https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip',
+				'latest' => '34.0.0',
+				'internalVersion' => '34.0.0.12',
+				'downloadUrl' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip',
 				'downloads' => [
 					'bz2' => [
-						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.tar.bz2',
-						'1' => 'https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.tar.bz2',
+						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2',
+						'1' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2',
 					],
 					'zip' => [
-						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.zip',
-						'1' => 'https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip',
+						'0' => 'https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip',
+						'1' => 'https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip',
 					],
 				],
 				'web' => 'https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html',
 				'eol' => '',
 				'minPHPVersion' => '8.2',
-				'signature' => 'ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1
-/VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid
-2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB
-3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA
-4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrIS
-ILUlWHKNuhVMDCWn0BkbFw==',
+				'signature' => 'wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+tROcuuq4A6jcCjhT178clw==',
 				'signatures' => [
-					'bz2' => 'W/tiziEGARA4TVuHMOa51iu9HcPQkbM+x8NkwHUc1WET+jYEzhUZY0xmL811U7H8
-3mbdabIb/5acIpVma+QNJE65kiNrkYPdPD1mOpHHtv+ORyH+KAhuLQ668fYNysvy
-KVapOcEkQHtLFVM9vT/wUqnVbHgFd0efgSz9hPzrS5Jm+MoeRvIGfEB54WPUgI0d
-HtB6/kPdL0vNMU2zEgZksDg0vhqy2UyNqXR5pcjbhRla4n5W4iYWYlMKXMHb30N5
-1fvp5YwioA6Ll/2/tT1MHEdpKOlKRJ61kPAOt+kcRZHtjI16UezC+DE0b6gDXxAA
-yfBdiRBgE/aekFAIWtOdfQ==',
-					'zip' => 'ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1
-/VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid
-2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB
-3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA
-4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrIS
-ILUlWHKNuhVMDCWn0BkbFw==',
+					'bz2' => 'Xcmsalf2JFOERdm+glnMIgwKJP7cu3CK1Kt9doIIELl+0/W5nJp98ZDs29m445/e
+TZPhjOBDcu1xw/AblUNeU0eAyNQflMhtT82Zoe4eKiQ14/Oerh+M+/t7O3dmqbDw
+W+2QAteOHSeKcWb+m5KSWEWW81M+OiXPCauLnYVP6oG66Dn2Wqt6dOAjwLpn6z02
+uGWTZy+4C0Uok/kY+xtmsy/uiIiZvvuVZFdGGh9eKhinr8PbCyvON1pFmb0FjCi3
+Ybg2VWxS+M9hm9DErFQcEHuf2O8QRmWsUdTC8+Bghp0pMHYju8ftKcRowQkBu8c/
+7RQFy55zpZaPEo6+0weB/A==',
+					'zip' => 'wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+tROcuuq4A6jcCjhT178clw==',
 				],
 			],
 		],

--- a/config/releases.json
+++ b/config/releases.json
@@ -1,123 +1,124 @@
 {
-	"9.0.58": {
-		"internalVersion": "9.0.58"
-	},
-	"10.0.6": {
-		"internalVersion": "9.1.6.1"
-	},
-	"11.0.8": {
-		"internalVersion": "11.0.8.1",
-		"signature": "jZbAdJ9cHzBcw7BatJoX7/0Nv9NdecbsR4wEnRBbWI/EmAQ09HoMmmC1xiY88ME5lvHlcEgF0sVTx6tdg4LvqAH2ze34LhzxgIu7mS1tAHIZ81elGhv66VuRv17QYVs17QQySikKMprI+mzdTjIf3rloc97lpm9ynQ+6vizwdxhZ0w5r4Gl85ni52MpeN1ZdSx/Z9LJ0bCIO9C+E6kyQvjI7Q7A+WpMF1SiQL2RJsLJERtV4BP8izVuZQ/hI9NDjrdZAAiMKh8jB0atDNbxu24dWI2Ie7MvnzadL6Ax9+qIWUzlZIqX9yXgFVE2RsGVSvbaIJ8CiZnKdMBDAdXAVMA=="
-	},
-	"12.0.13": {
-		"internalVersion": "12.0.13.2",
-		"signature": "jZbAdJ9cHzBcw7BatJoX7/0Nv9NdecbsR4wEnRBbWI/EmAQ09HoMmmC1xiY88ME5lvHlcEgF0sVTx6tdg4LvqAH2ze34LhzxgIu7mS1tAHIZ81elGhv66VuRv17QYVs17QQySikKMprI+mzdTjIf3rloc97lpm9ynQ+6vizwdxhZ0w5r4Gl85ni52MpeN1ZdSx/Z9LJ0bCIO9C+E6kyQvjI7Q7A+WpMF1SiQL2RJsLJERtV4BP8izVuZQ/hI9NDjrdZAAiMKh8jB0atDNbxu24dWI2Ie7MvnzadL6Ax9+qIWUzlZIqX9yXgFVE2RsGVSvbaIJ8CiZnKdMBDAdXAVMA=="
-	},
-	"13.0.12": {
-		"internalVersion": "13.0.12.1",
-		"signature": "GRVpINAV11LUd+UxjnQtb2gbFHaxNrh9WzzQgPpjaKJ6J28PRQ9sq8J1GlfEN2K7RnD/6pFkDRTlBOU56g4XC3GgDpY6F88OVQ0z9D1/nudSZV+cSu6xRuC6q7Z9sStGoyDn+o4Z8c+i2yR6zcoVD5itXiU1w41fMT/dlzCtIDmo953+K9fNlTPlU9h9H3MIHVECrm+3NmISmI8+5hl4Ju5p8tudxVhGF2aHR0ilG0ff+wjdz5CtsiZXoP+BUNn+VFRfhy9vBf+VD6khhFkDXSymw0X6xNN3lMqQIJmJPsPONDXtk2diY6h204uEUofPyiBfUT4yVTwIOt+tnqZzzw=="
-	},
-	"14.0.14": {
-		"internalVersion": "14.0.14.1",
-		"signature": "Nw1PhE391uasWeU66JtBoJGTRHDdImBNBkpMlh4nTG6UJFouFTDDmqHq6DcanS5eqoC79rxiC7lloaN/05AZ7AY1FSNjG5G9xPM4OWgTCbwXhUfD3DjGVzzbMVnTWgeKZMgZqqU8F4uWHkcEB0fqImZYnFMdX7E7xZmEIO8BSOOdS6PvvZTAeDXEwWSBMRVa7wEYp/hwJzV3UCy5SThYHqs+8EIdQeql1/3o/P/0bsGnsgpLGK/2bV4lzVV74m3TRrZ6EDdSnGyybYX4QGv/wfng9RijMdMdr1SYzJfkRKj+JX37zgscL/87XgnApkQSFaqAZYszh1hjGEyQaoibXw=="
-	},
-	"15.0.12": {
-		"internalVersion": "15.0.12.1",
-		"signature": "ky2vKMSu1tjkpsPaAf6CkqtKJwkeZ8fxT9a9TBNwAAbl3AAIYqQKjT0Np5nvFwzbZ9N2axbhWdy0WuY7ffxDwYL7lKzzJ4nfeYzIVJV49y1W2kbz5KvDhX4/ACgGw42mWSmJdyx7hnp5JdcddA/eZDh2yrffC+MjrSaZXBvitnxMtI2xaeOUpphvjKgy8wF+Cb8hjiKCAbhG11F2qq8TpX79l5I1n32RhvhJMc1GXmSSlR+dKK0zVIspW9ENMsRcxsVlYeI9cGdGpShVj4eC3ya2ZZ0KFsEwwvJlOjXbJ8Ctw133fWEp/1nGFuiCP3sZnfCSJ75Tc780Fqo0Q4pc8A=="
-	},
-	"15.0.14": {
-		"internalVersion": "15.0.14.1",
-		"signature": "A5WWizBmhSC+dfJNrA3eNjx4w3w9i+9GKs0TWCEOAi74E1gfQymaSa3UNdm/fjmPOsy1fnmICjDfXoIwkle+dlfAbwg2faRkF1px9a538Y5XXTXZ63P5JXABHYSvIAY3QDk2CwzM4tSiL2rf7tGgG8uxtvXkyG7DfHH7BweKFBPQ0Ly2ESiSHzVagAHo7f/Ox3G7qC6o4g8pVPfVyXhOZcwf29et9DY3xtKluMQxrmHVTQ6mJ65IRny+/MNMrjwf05B0WC1WDnIiMAfUcEMovxuqoFexvrpnJ9ByOPPLTYMWfpQcJHjw4FiqgFQ/of/iDvYBQvWAJx0Q7tV9bofZjA=="
-	},
-	"16.0.11": {
-		"internalVersion": "16.0.11.1",
-		"signature": "b7SOD6KATY0bpbAcL/+1gdeLeuWAvsIn+tuUzF6HStrjxLrARw8cOrM7bCq5zcq7tJCWrI2Ww9CrKH8kNalEZNMDZy346QhYkUZNOiU2IP8wdb1601vRXfIkPyTVSpdkRDMQWtIushwa/WIZTKnJWo1fd0juxBnbmIl30rxDgUpBOkjx0zGvA2Ff+mssezX3qGhaB0Btr45xpgbHbeEQwsH1w2PXJFy9GsF2psbBEIykCPAxgRWR32bTGH8ws9UyzpAxCj7W4wEnJFhsQ2zb0Wh5ZjSA9G1SARJhMp/8Efwm3uWJr5xK4MYKG2bQ29mtHWPTEBalqX2V9enOLAgVWQ=="
-	},
-	"17.0.10": {
-		"internalVersion": "17.0.10.1",
-		"signature": "UNo0Sh9xK+TlO6rL6s380gB436990558QOjdQiDaeYuFANjCQFz0aO957FetpkolidhfkICTMtBC5mlSVAJjMW+5BIQ0kAHeJykqz6YD4Vw0aEIHHFgA1qCEphEj0/D5p5OzkP6JSkwp+/e1O8xFdr/8VIHdkCEM5Kd5lchzp83XmfZm1t6YdcV8ziACDZrTGaiG/TGRdHeR4ifgMpdMLZIy0x4Qd6k06dhCFsEz8H10Cf0oVmtrjxJsKEPY7doW4QZIg8gwFj8Uxk4ylijHFSeIxCX96ZSmj+7wolAn8kYqq5Q8iwVYjNqFtJZ/YXIccNaaoBpx0s3QFdfhSnSgQQ=="
-	},
-	"18.0.14": {
-		"internalVersion": "18.0.14.1",
-		"signature": "nzM1fD0IYCr86Pb7fJLGQA0usVUOKE+JyFVVhJArh4BpdDI0C2yC7l2zeJgCEd+gRiXGB1N5a7GTfNSqdLO6ho+5dEg55OQYiTE75ji+dTKz9IDz99crk4BiYIsKc+btZtuq8p/kxJK7wkRlsxDTULQWlVe0f1shX2sTCg9CNYzY5/kwmQtz8OQ/umwya1sFFedS379Vnpa2NgAEq9W45r9hP6iZmKDBlwrY+r/pBWaJteI9xW9Ag8hhv4pSku0qBX4Qwl1YI2f8b0KHy3yIqmY58qsWTjGb319Nq3tPFsY8N2hUmFu4yve0nW6Zb/+1OcrbOha2Z819kkukqEE34Q=="
-	},
-	"19.0.13": {
-		"internalVersion": "19.0.13.1",
-		"signature": "qWFamMWZegXESQawjDX9Zn5XHVNUElbOfmVKyCG/MWqTfX0cUIt/xDOccSK24hce8M47spBztkAKLEqsCBfwwmnpqDL2iVhuQVAwHuOyev/53lfdge5j7AH4yqPAEa+jXDdnHtLClAtYI7QtIeUAhuj0ychW47rcWRNsZ1tTxKGclZqPubiMd8eO6kn8S/uPSnaqLa3zSAKlqrda4qsvt4AnGfOB7/MZxQBO9Sy/D6F60DqvI9/IntjJyJm6uUzo+ziDzSgzCHt8/tFdbtjLR1j3zEv5n7epNdTZuj/Z3FVbBi4HSk9oOHa6LQTeqAeAWN2PwtM3nn6/5y0BMhJueQ=="
-	},
-	"20.0.14": {
-		"internalVersion": "20.0.14.2",
-		"signature": "ie2H7/drKls2RxE5aS50ocGeXIBiAlczHvhCeObYF21s0qQtx0mGJe6TUvA8diQ5T3ZiZwRLQT2BH6GKHbOt6ku6RRSTILhglffUAv3CellNrYmkyAl1ob6/4H5/XHjCDgQ6Ykglk7xvQICw2l7s4tfa8KNIWLdPuWfUvXBBDsXKtFEmv8d0SU+f/dQR6JKuuLzb1cmunoldyvH/qC4XdKx1r/JqPEaQxW7l3WQeXaLCA2OiLxIBcHH6ucNJ4ik6fZCxpy3szm7gaozWquGfD+oglIY7GLVsbeZBTDFgF44OcDAY/29AL3TKRKN+cnQr6feVFe2PlZ2FK5zxWZNYfw=="
-	},
-	"21.0.9": {
-		"internalVersion": "21.0.9.1",
-		"signature": "UmaMy3Rp14wXYO8IQPzJWIsJnz5po9Fw42upR3ci+EPmfpptUgCpxDBZ+uIMLpIfEe9waBv1ZPRgOaUmzwWQUGzL+z1+LRMe9rm/m2SKEYDWzq0Uk0wmheqAdhaZHFYqEIXWXKMauXl+KxdNsJOftU96NzoiWTO8m4JjT7758fyGuio7jRWHCun1m+nb4hSDLQHdC1Ipng5IPFcR2EJ9zP+SpLR7pO7g+2raxlnLhvqT27FfiTAw3J4ztm/BsGTWBQwO9DSgH23A3veRLMpZnuiZcZfOJIr/LSRjvgxU+RdHKWFJkmngNQAg7pTPnjMHmE2YG/R4IKW+A8xqweVzig=="
-	},
-	"22.2.10": {
-		"internalVersion": "22.2.10.2",
-		"signature": "XDDYmHMD8famkqCoed6EmUO4PNL8YsMOv859HOmcPThrQ2GcTr0jeX06oQ3ZrRsCwkfN+idHSOwY++S/qN7Pp65/isSfVU7LSYn/ELEnyRC5l8M1g1F/By4Bj8Np+7mAHIJmvvAKiVflOGPHWIhcXin1whDXeLXxpz3ntHR02XARLgozkbnyOrjxmkcx0BOkyyRgxVQXLR1QsFUhrt8+zjlhL/JsEHzCQ954n0mggdx8IhiEUqpHFjubwQbEytX9fhlPbaifQKypXBpBdN/RBRt6Ox5z2lSG5IY/g8nc4x7rYQSpiTrtWi1vlcxF0aITGorEOAeOrtcV0ba4AVoETQ=="
-	},
-	"23.0.12": {
-		"internalVersion": "23.0.12.2",
-		"signature": "tu+v9XHqXSKxncQi5ps0Sz7DHZ8l4sXAPw/8B2REvlkw/YC8OMSpnTy8LSKKgIdZsFsVcvA0Q6l84Xve6cxE3XpRKxSAxWJbamsmE35HcLwxVtuwpWxyOFD9xUzDVCVfnZfQcDUjeK2xQxV+qVjuPuoz0TmRwcZJwrXk/nZiA1cAV/k2PPG9FP25R8WAdIQDrfrM7C5GWPNSzv9qcUteJ4jv9ORJ/FiZVewSfP+5hKxTIeUw+D/9LbCjRVzKwvIx3r9oA+gwN2zYNOuYFvpF9FtVtJ9NLR/EJWBoHWLuO0XcrXgVWoemwF97nFeV5HdpPlWRhIoX0XzP82+TC5b1dg=="
-	},
-	"24.0.12": {
-		"internalVersion": "24.0.12.1",
-		"signature": "aCQnJpJjf83glgpOxTs1tenmKYhdBK34JyhBtwhikoE4bg1GpfNPe+5OVEDkKPLio3tAWWdx8SAR1+PuLYwjkyy6hhr80ojDrhnmjVprB9PZ5Dqqz9Uk5sLjyse2e0FCL9eCQfFLRMxNYyucp8ihSW2100KbDKPXq5K/GUS/9TuLV99JdwJjAWtPQzsm5KK93SMqwkuwWg+39qVS9W1w4zWjAwfP1xyJUFTIBeS35hnmnol2goE0JbSlTMoBYFyQPC8WFtnBG8EIA1ncyQ/IDKUZjg79E8cM8zyIY8PYmA/Jf4MpTMwfoGJQ0GtD6nCFACWMWE93WNcq+HBa025zsw=="
-	},
-	"25.0.13": {
-		"internalVersion": "25.0.13.2",
-		"signature": "FVPFITm49G4y0pv7xo9XWeLw4zKopsAwrj2iVSW2je9Nq2U25RpudHkrSwHZY2JDFsjx8xFncgjHT1iiuZJHBOkInfmJYvsBe3RVuS87uLhmeVevLKwBC+ZkgbRiMwX8j6TaNthAVOlYaowAQAjyRgJ8AAg3L5liYmqhobBUgtwd86wRlzk5Fy9MTAM3BSwnJ5CqVqcGxVBCJdTp73oryXSctu1lHS4zS4eMWaqSPrCDb4uSMyjE4DESH60dwVyRX6IrjOfLlNvurihALJuhJzqWG+Xdi3xurMOI65ad8im2+7tiB/yu5Bb5NdSl8KvLc2rOEZwqzv2p7fWh4Ovl6g=="
-	},
-	"26.0.13": {
-		"internalVersion": "26.0.13.1",
-		"signature": "bvGxFDuB+F5C9DqiARiF9MifdcZEQ2R5+AvgCEs/hnrUugRjTXMvJPRkaDLL01YfQoiNwNG3da/2JQEAfZ23YkQedNQ6T3fs7HGbhUZA3xFZb06kxQpLJFI/Ncei8i16+QyxhlQtOlhBG0ExG0M0LD3Ow9ZFsCkRk1Ja2YIRBW3mRUdnqew8mYYKltZJL444D5BO/0AisCh9hVI7JzExVmwYL/HOmbG5GBpy7BLJnSOUU0Di5PSfwoLIOqLsg/9+qVqpedb3ivvwVR1pZqTUyrUPDYojLnyw3XCSKb588U6kSNhaMj/Kl5/5KT34OG+2m04vBdfnV+VUhCBz0tYn9A=="
-	},
-	"27.1.11": {
-		"internalVersion": "27.1.11.3",
-		"signature": "brs2KkUu60QmFZD46rSTyg3qBSlYnv584xeFNWLl2ZM4cwItzJ5wXeajfrPvoUQJGWw7Ln4pQPHja4GrYaNfrKewbBzdJ295glFA5Biwk8OaacsAh6lZm4QH87OUjvgS560LH0hW99Jf9aFv/qqj56T0GSGlGS3qv/HNimmeC0sZfLNDdxjaDWBpVJkt+45ZvJJ8XVSDOlNNKjcgvcUMrsDItXioSwBst6vTdR5IKLAFivlb7HYLUN48R9h57QM2v8X/N49mF+Wk3PQa19wBVsUFYkaQuG9FTjUVgvp8bgv3s9rhrOLJa5KUOpdcodgZfaeql723PcZEzPJ3dzisSw=="
-	},
-	"28.0.14": {
-		"internalVersion": "28.0.14.1",
-		"signature": "e3wnEZE0ooyNX8CpsSEgXafLoOU/U+zORUyeqKczWuuf2Srq4edl2SCaQgvdSLsGDZo8h9LLEsh544/NyS8VOY7aJVqR2JOC4bUyztfNTnlppRLVTCIXx053Eht9+neNpYlPy8hBK+KBLoN7q3WYcWL1QOIrUAzgxhjwshMrTxNrHi8Nq7g37iZUzhPU5HWwMUID9gsQnT+aFurooLVvWMM8Ad0RkU72i5Y7I80c+v/2MYE9rxUmNC54noVePvrjR8zf/PC+Yj1vxFZ0hYAtweLgBxfwU5cNBYfH7M1I9FLlb88p/XDWx6XaBz4Ql6LKlbpDxNE9UiM09JG1dU7Ebg=="
-	},
-	"29.0.16": {
-		"internalVersion": "29.0.16.1",
-		"signature": "rouEEVNhNDWtZcK4LRDcYCZWS8zkSEWcjgJcbJOGnIHtH2GX4cxLR17gYpetSzfGGF2Dgv01dUXQw8FHI0ygaEOWYO+xz75WN5tuW3MsZ70u0xZF7bHejkv0YHHwyMjg6nei9Xn2FUTwmCpse6Lt6F5NUZD3Eq1ODrE3U1FKU6PB67tE7Q8kj13r7oJQ+SKwSO1Tn/u52YMmiGyzdmFK9zSRwa7BqkpgHVpVK+wjCkI/jk0ohUr8gcfS755BbflEDa0OcyJLoyz0qWyzsFAhSD7Y/Kbr8Y59wi77Z3jUUpV9IeHFmQy9OsqjyrRtIHtjyHoib4f8qGhnvNCT5Q/wOA=="
-	},
-	"30.0.17": {
-		"internalVersion": "30.0.17.2",
-		"signatures": {
-			"bz2": "Eazfs97Esa+8x4pAzvEq4zdsZnzTUGG05bdAUgPthbvg3ScgSs0J1FvlrZCL62kNXfA/oDAkVTcX7ub0J+C7+wPJp7sfL9awV03H/5365eME85eR+AM6sayTCruRuqkfNaWCqcbLyIC7StJngSiFbeE8vi+yG/6p42x/ZpFi0d8QoIP98DXsrMxQImVPsZtSoWdLkwgl+r/2Rh1pp98KI+fpj8Q2rRKE2o211yYPrRPfwMTn5v85yMqpcnfCKPcrUzSVnHaX3wGycE4TRS5T1AXB6ua74hHYNCeBBtDPrFEF2MuBC0Bwji/WjC6mCL94hlK0PeYrgZ7QR5juCzM8gA==",
-			"zip": "bKCHRPqnAOGlv1coBuKMbG2ndH+VoO4R6Gk7LXcRk9oLJ/LhewbMQtPsyVuc2dNeWFTBxxm1jNwXuKPiKLfX1J8ZVbAPA1hIPom3WSt5kpBO+xS+hZGS2I+IDh3tmVwbUyuloprC0iWBrQSPqNj0Ov6BK9iN+wiB+Wh1UIL7ln619CtJx3pj49QSFL0kMq4KXb/jm2i0Yqwh+XUJyG4Rz2UCkxeCgj6V3szC1fMNzZK1C1u/X+jA1j/OgyLxtmz98Ub1U8v3WDOeDwyzG+DjjXvu4hrm8zZyu6+11ytlQG9YPfiZ0momiAQBHo9OVlBsdP5deAwX1CeMH4+yk2kfng=="
-		}
-	},
-	"31.0.14": {
-		"internalVersion": "31.0.14.1",
-		"signatures": {
-			"bz2": "r/9cFMXfoPhbXuBDKvNr0ZqWY2wXsgFJwXTokeA7qhAs5Q/TTolxsYJlS5TQUKYS5CeFqtwRq8UsJ9LtpB0IMn9BsgZ+JcvvyhViNdX5owfDw7X25JCB6Xfq0zBK3n3++bZawQafGD7Y/JRGVe6GaMk+IGTHJjabpHtDtRCvQj2LdJ8kAkj7CKW8enfROjgst8FRm65iAs9wru22NdG18YK5/1pi1HYE+FnZgVSS4ywFzyCtqWdlYGLtifAo8Ok9KLcsskAkZCRYeJS/kY7HDfFfVvJaKHsHLKFSnSYU28xDp7QsPHBRKDZip7LrcpHt9sAJugBvNTxBojJVRwXREg==",
-			"zip": "oM4xe+KQxwzwGXq0JwYbt6xRsgu4Ejf9vrdNrNPZB/dnEDq/EWFLBJXoiq4Hfq+xIrJz+Cok4RjPg/NdNl/A+fWC47aJh+gPZUw0BITf8GZ/BeAzdlyxUG9+VrIMYEARr93DL16y1mCk7dkkMC/a8DT5/orqXnWIP38wgXzbU+DcyA9eCq28+aSz25MLYSHRedNnmki3ovqsa4K6/5D+RvcXXwn4/xnk5Dboi8akNSEnXfmTpTJs8D8HqAXBruklPA45206JcfSACC5ePc0ZfUPrV3ToKFlijsBdIsuNgpzmOIwukB4MUO+RLyk4lPOGZwCpfYewGDvrElT50aJYkA=="
-		}
-	},
-	"32.0.11": {
-		"internalVersion": "32.0.11.1",
-		"signatures": {
-			"bz2": "NGJLWSS5LG22tuRHNgIc1wXeX7L+NxCfW9p7bsGDJ2tPRbhSI95TMg09EWILZdg0n+XO+LAMzT3VPO/DtMLM8IOkhnAjT5cBlCdjF3alTAP7aZKA05vIgTxYq9J5HTSkvT3eolazQ8vXnDxkAEAGZpvHyXsIFKLMdyMtZNEYOvKiteRwnSyGR41v/5plgbRVuzKKT1ed9e9J1V8CKoJq/Yhaybt4jlSkaSCAA37iKwz0vECco6Jjnhts8l6cjRvxQSmoU7VtyXJAJbOU/EPT0L4PnZBJ6BkaxbtEJLyuAkqtMLWmyjWiFaVvJ803U9OLKj8h7Sxlq3dnZ2hAGKTB+Q==",
-			"zip": "fjrCxIdnySTTWKZifdp5+2SUF31Vv7d2JR0i8LL6O7NZ76xmKk8mQY44ecwNErUsUbbEFO/s0WUbFGgU4ZUvDaxjYlQYYXkUAD6PSl/UnN/RBIQJhi0haM5oOsa+90oeb65FFNyX4uGHjAWMNhv9ChZc5rmZgv35lmMLMJ2O4W+1xhLabppucMWEvwd2+EV2V/Iy9Qo5gZx82vCbZigpn6OQo011DiRY1Q4i2hlirZsp8Jk18CjAznZQ0s+1RxRfEWl89AtaAYE7NPBhMYb5hTsDzRVizVUU3YYTCWqEpd4DV8q4RywFN03K9oiJAAdZyvE6RPkGve7ePndOyln6mw=="
-		}
-	},
-	"33.0.5": {
-		"internalVersion": "33.0.5.1",
-		"signatures": {
-			"bz2": "ZVV1ugYQIUnV6DreCzY6MDSiqnH7QzAk/KaNSodG/cxVhqan20JCpFnxUuakBvL723H4gOaAzOtehrMTqNKxH+6vdk3Fri9Iv45t4M2uNIkWDrsviaqvrJN3zj43Wnx5G4SfEVa9WoKvhVDZUGWb3B2i3jiR7zbLf8kkXOIZfn/NJD3i/fnWC6wTxAl9zzFTDUuNQZO9CPX/u+AwYG6WL4MPlzSiHKUYqtWS7IYPPaK8ji4MxHVkz8phtG2P51r7zBvvvZ4m9RUd9NKHtj0pvEvv4eyhz9OF/JigjeGIYx3eIqgKhO2YQ1irk+CKiqHPmOPcSrbqMCEewD9BnNSiNg==",
-			"zip": "srq41voRX6MJhV4uKhKD63uZMYQ0OVrTfdC2aKEY6st/dVJtEa9Us5Gs8HCS0sJ0o5TzKh6vQ7ETyugEWoussxlLrdbsbkAj4D48zF4MOjhxVcsZd7SybTQkzVtd7JVCRr4RdAdARd9PAGJrTDWQlDi2SW+F0T9ZpZ44rlesWLWTH2OZlIsQLFGKzcuO21XiyDdkbvVmX9MdxwlFmxtlEpPliZNEVzJ0yBv9uH/je2WnRk8u2Evu5VS1I2iTfRoCp24a00mGWzUJJVD2hMVktzBecm0ffoI0Phe1SngOqljAo5r5LCiqKswtDjD2Cfd+Q36WWyhFw7is33ZSGoRW8w=="
-		}
-	},
-	"34.0.0 RC5": {
-		"internalVersion": "34.0.0.11",
-		"signatures": {
-			"bz2": "W/tiziEGARA4TVuHMOa51iu9HcPQkbM+x8NkwHUc1WET+jYEzhUZY0xmL811U7H83mbdabIb/5acIpVma+QNJE65kiNrkYPdPD1mOpHHtv+ORyH+KAhuLQ668fYNysvyKVapOcEkQHtLFVM9vT/wUqnVbHgFd0efgSz9hPzrS5Jm+MoeRvIGfEB54WPUgI0dHtB6/kPdL0vNMU2zEgZksDg0vhqy2UyNqXR5pcjbhRla4n5W4iYWYlMKXMHb30N51fvp5YwioA6Ll/2/tT1MHEdpKOlKRJ61kPAOt+kcRZHtjI16UezC+DE0b6gDXxAAyfBdiRBgE/aekFAIWtOdfQ==",
-			"zip": "ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1/VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrISILUlWHKNuhVMDCWn0BkbFw=="
-		}
-	}
+  "9.0.58": {
+    "internalVersion": "9.0.58"
+  },
+  "10.0.6": {
+    "internalVersion": "9.1.6.1"
+  },
+  "11.0.8": {
+    "internalVersion": "11.0.8.1",
+    "signature": "jZbAdJ9cHzBcw7BatJoX7/0Nv9NdecbsR4wEnRBbWI/EmAQ09HoMmmC1xiY88ME5lvHlcEgF0sVTx6tdg4LvqAH2ze34LhzxgIu7mS1tAHIZ81elGhv66VuRv17QYVs17QQySikKMprI+mzdTjIf3rloc97lpm9ynQ+6vizwdxhZ0w5r4Gl85ni52MpeN1ZdSx/Z9LJ0bCIO9C+E6kyQvjI7Q7A+WpMF1SiQL2RJsLJERtV4BP8izVuZQ/hI9NDjrdZAAiMKh8jB0atDNbxu24dWI2Ie7MvnzadL6Ax9+qIWUzlZIqX9yXgFVE2RsGVSvbaIJ8CiZnKdMBDAdXAVMA=="
+  },
+  "12.0.13": {
+    "internalVersion": "12.0.13.2",
+    "signature": "jZbAdJ9cHzBcw7BatJoX7/0Nv9NdecbsR4wEnRBbWI/EmAQ09HoMmmC1xiY88ME5lvHlcEgF0sVTx6tdg4LvqAH2ze34LhzxgIu7mS1tAHIZ81elGhv66VuRv17QYVs17QQySikKMprI+mzdTjIf3rloc97lpm9ynQ+6vizwdxhZ0w5r4Gl85ni52MpeN1ZdSx/Z9LJ0bCIO9C+E6kyQvjI7Q7A+WpMF1SiQL2RJsLJERtV4BP8izVuZQ/hI9NDjrdZAAiMKh8jB0atDNbxu24dWI2Ie7MvnzadL6Ax9+qIWUzlZIqX9yXgFVE2RsGVSvbaIJ8CiZnKdMBDAdXAVMA=="
+  },
+  "13.0.12": {
+    "internalVersion": "13.0.12.1",
+    "signature": "GRVpINAV11LUd+UxjnQtb2gbFHaxNrh9WzzQgPpjaKJ6J28PRQ9sq8J1GlfEN2K7RnD/6pFkDRTlBOU56g4XC3GgDpY6F88OVQ0z9D1/nudSZV+cSu6xRuC6q7Z9sStGoyDn+o4Z8c+i2yR6zcoVD5itXiU1w41fMT/dlzCtIDmo953+K9fNlTPlU9h9H3MIHVECrm+3NmISmI8+5hl4Ju5p8tudxVhGF2aHR0ilG0ff+wjdz5CtsiZXoP+BUNn+VFRfhy9vBf+VD6khhFkDXSymw0X6xNN3lMqQIJmJPsPONDXtk2diY6h204uEUofPyiBfUT4yVTwIOt+tnqZzzw=="
+  },
+  "14.0.14": {
+    "internalVersion": "14.0.14.1",
+    "signature": "Nw1PhE391uasWeU66JtBoJGTRHDdImBNBkpMlh4nTG6UJFouFTDDmqHq6DcanS5eqoC79rxiC7lloaN/05AZ7AY1FSNjG5G9xPM4OWgTCbwXhUfD3DjGVzzbMVnTWgeKZMgZqqU8F4uWHkcEB0fqImZYnFMdX7E7xZmEIO8BSOOdS6PvvZTAeDXEwWSBMRVa7wEYp/hwJzV3UCy5SThYHqs+8EIdQeql1/3o/P/0bsGnsgpLGK/2bV4lzVV74m3TRrZ6EDdSnGyybYX4QGv/wfng9RijMdMdr1SYzJfkRKj+JX37zgscL/87XgnApkQSFaqAZYszh1hjGEyQaoibXw=="
+  },
+  "15.0.12": {
+    "internalVersion": "15.0.12.1",
+    "signature": "ky2vKMSu1tjkpsPaAf6CkqtKJwkeZ8fxT9a9TBNwAAbl3AAIYqQKjT0Np5nvFwzbZ9N2axbhWdy0WuY7ffxDwYL7lKzzJ4nfeYzIVJV49y1W2kbz5KvDhX4/ACgGw42mWSmJdyx7hnp5JdcddA/eZDh2yrffC+MjrSaZXBvitnxMtI2xaeOUpphvjKgy8wF+Cb8hjiKCAbhG11F2qq8TpX79l5I1n32RhvhJMc1GXmSSlR+dKK0zVIspW9ENMsRcxsVlYeI9cGdGpShVj4eC3ya2ZZ0KFsEwwvJlOjXbJ8Ctw133fWEp/1nGFuiCP3sZnfCSJ75Tc780Fqo0Q4pc8A=="
+  },
+  "15.0.14": {
+    "internalVersion": "15.0.14.1",
+    "signature": "A5WWizBmhSC+dfJNrA3eNjx4w3w9i+9GKs0TWCEOAi74E1gfQymaSa3UNdm/fjmPOsy1fnmICjDfXoIwkle+dlfAbwg2faRkF1px9a538Y5XXTXZ63P5JXABHYSvIAY3QDk2CwzM4tSiL2rf7tGgG8uxtvXkyG7DfHH7BweKFBPQ0Ly2ESiSHzVagAHo7f/Ox3G7qC6o4g8pVPfVyXhOZcwf29et9DY3xtKluMQxrmHVTQ6mJ65IRny+/MNMrjwf05B0WC1WDnIiMAfUcEMovxuqoFexvrpnJ9ByOPPLTYMWfpQcJHjw4FiqgFQ/of/iDvYBQvWAJx0Q7tV9bofZjA=="
+  },
+  "16.0.11": {
+    "internalVersion": "16.0.11.1",
+    "signature": "b7SOD6KATY0bpbAcL/+1gdeLeuWAvsIn+tuUzF6HStrjxLrARw8cOrM7bCq5zcq7tJCWrI2Ww9CrKH8kNalEZNMDZy346QhYkUZNOiU2IP8wdb1601vRXfIkPyTVSpdkRDMQWtIushwa/WIZTKnJWo1fd0juxBnbmIl30rxDgUpBOkjx0zGvA2Ff+mssezX3qGhaB0Btr45xpgbHbeEQwsH1w2PXJFy9GsF2psbBEIykCPAxgRWR32bTGH8ws9UyzpAxCj7W4wEnJFhsQ2zb0Wh5ZjSA9G1SARJhMp/8Efwm3uWJr5xK4MYKG2bQ29mtHWPTEBalqX2V9enOLAgVWQ=="
+  },
+  "17.0.10": {
+    "internalVersion": "17.0.10.1",
+    "signature": "UNo0Sh9xK+TlO6rL6s380gB436990558QOjdQiDaeYuFANjCQFz0aO957FetpkolidhfkICTMtBC5mlSVAJjMW+5BIQ0kAHeJykqz6YD4Vw0aEIHHFgA1qCEphEj0/D5p5OzkP6JSkwp+/e1O8xFdr/8VIHdkCEM5Kd5lchzp83XmfZm1t6YdcV8ziACDZrTGaiG/TGRdHeR4ifgMpdMLZIy0x4Qd6k06dhCFsEz8H10Cf0oVmtrjxJsKEPY7doW4QZIg8gwFj8Uxk4ylijHFSeIxCX96ZSmj+7wolAn8kYqq5Q8iwVYjNqFtJZ/YXIccNaaoBpx0s3QFdfhSnSgQQ=="
+  },
+  "18.0.14": {
+    "internalVersion": "18.0.14.1",
+    "signature": "nzM1fD0IYCr86Pb7fJLGQA0usVUOKE+JyFVVhJArh4BpdDI0C2yC7l2zeJgCEd+gRiXGB1N5a7GTfNSqdLO6ho+5dEg55OQYiTE75ji+dTKz9IDz99crk4BiYIsKc+btZtuq8p/kxJK7wkRlsxDTULQWlVe0f1shX2sTCg9CNYzY5/kwmQtz8OQ/umwya1sFFedS379Vnpa2NgAEq9W45r9hP6iZmKDBlwrY+r/pBWaJteI9xW9Ag8hhv4pSku0qBX4Qwl1YI2f8b0KHy3yIqmY58qsWTjGb319Nq3tPFsY8N2hUmFu4yve0nW6Zb/+1OcrbOha2Z819kkukqEE34Q=="
+  },
+  "19.0.13": {
+    "internalVersion": "19.0.13.1",
+    "signature": "qWFamMWZegXESQawjDX9Zn5XHVNUElbOfmVKyCG/MWqTfX0cUIt/xDOccSK24hce8M47spBztkAKLEqsCBfwwmnpqDL2iVhuQVAwHuOyev/53lfdge5j7AH4yqPAEa+jXDdnHtLClAtYI7QtIeUAhuj0ychW47rcWRNsZ1tTxKGclZqPubiMd8eO6kn8S/uPSnaqLa3zSAKlqrda4qsvt4AnGfOB7/MZxQBO9Sy/D6F60DqvI9/IntjJyJm6uUzo+ziDzSgzCHt8/tFdbtjLR1j3zEv5n7epNdTZuj/Z3FVbBi4HSk9oOHa6LQTeqAeAWN2PwtM3nn6/5y0BMhJueQ=="
+  },
+  "20.0.14": {
+    "internalVersion": "20.0.14.2",
+    "signature": "ie2H7/drKls2RxE5aS50ocGeXIBiAlczHvhCeObYF21s0qQtx0mGJe6TUvA8diQ5T3ZiZwRLQT2BH6GKHbOt6ku6RRSTILhglffUAv3CellNrYmkyAl1ob6/4H5/XHjCDgQ6Ykglk7xvQICw2l7s4tfa8KNIWLdPuWfUvXBBDsXKtFEmv8d0SU+f/dQR6JKuuLzb1cmunoldyvH/qC4XdKx1r/JqPEaQxW7l3WQeXaLCA2OiLxIBcHH6ucNJ4ik6fZCxpy3szm7gaozWquGfD+oglIY7GLVsbeZBTDFgF44OcDAY/29AL3TKRKN+cnQr6feVFe2PlZ2FK5zxWZNYfw=="
+  },
+  "21.0.9": {
+    "internalVersion": "21.0.9.1",
+    "signature": "UmaMy3Rp14wXYO8IQPzJWIsJnz5po9Fw42upR3ci+EPmfpptUgCpxDBZ+uIMLpIfEe9waBv1ZPRgOaUmzwWQUGzL+z1+LRMe9rm/m2SKEYDWzq0Uk0wmheqAdhaZHFYqEIXWXKMauXl+KxdNsJOftU96NzoiWTO8m4JjT7758fyGuio7jRWHCun1m+nb4hSDLQHdC1Ipng5IPFcR2EJ9zP+SpLR7pO7g+2raxlnLhvqT27FfiTAw3J4ztm/BsGTWBQwO9DSgH23A3veRLMpZnuiZcZfOJIr/LSRjvgxU+RdHKWFJkmngNQAg7pTPnjMHmE2YG/R4IKW+A8xqweVzig=="
+  },
+  "22.2.10": {
+    "internalVersion": "22.2.10.2",
+    "signature": "XDDYmHMD8famkqCoed6EmUO4PNL8YsMOv859HOmcPThrQ2GcTr0jeX06oQ3ZrRsCwkfN+idHSOwY++S/qN7Pp65/isSfVU7LSYn/ELEnyRC5l8M1g1F/By4Bj8Np+7mAHIJmvvAKiVflOGPHWIhcXin1whDXeLXxpz3ntHR02XARLgozkbnyOrjxmkcx0BOkyyRgxVQXLR1QsFUhrt8+zjlhL/JsEHzCQ954n0mggdx8IhiEUqpHFjubwQbEytX9fhlPbaifQKypXBpBdN/RBRt6Ox5z2lSG5IY/g8nc4x7rYQSpiTrtWi1vlcxF0aITGorEOAeOrtcV0ba4AVoETQ=="
+  },
+  "23.0.12": {
+    "internalVersion": "23.0.12.2",
+    "signature": "tu+v9XHqXSKxncQi5ps0Sz7DHZ8l4sXAPw/8B2REvlkw/YC8OMSpnTy8LSKKgIdZsFsVcvA0Q6l84Xve6cxE3XpRKxSAxWJbamsmE35HcLwxVtuwpWxyOFD9xUzDVCVfnZfQcDUjeK2xQxV+qVjuPuoz0TmRwcZJwrXk/nZiA1cAV/k2PPG9FP25R8WAdIQDrfrM7C5GWPNSzv9qcUteJ4jv9ORJ/FiZVewSfP+5hKxTIeUw+D/9LbCjRVzKwvIx3r9oA+gwN2zYNOuYFvpF9FtVtJ9NLR/EJWBoHWLuO0XcrXgVWoemwF97nFeV5HdpPlWRhIoX0XzP82+TC5b1dg=="
+  },
+  "24.0.12": {
+    "internalVersion": "24.0.12.1",
+    "signature": "aCQnJpJjf83glgpOxTs1tenmKYhdBK34JyhBtwhikoE4bg1GpfNPe+5OVEDkKPLio3tAWWdx8SAR1+PuLYwjkyy6hhr80ojDrhnmjVprB9PZ5Dqqz9Uk5sLjyse2e0FCL9eCQfFLRMxNYyucp8ihSW2100KbDKPXq5K/GUS/9TuLV99JdwJjAWtPQzsm5KK93SMqwkuwWg+39qVS9W1w4zWjAwfP1xyJUFTIBeS35hnmnol2goE0JbSlTMoBYFyQPC8WFtnBG8EIA1ncyQ/IDKUZjg79E8cM8zyIY8PYmA/Jf4MpTMwfoGJQ0GtD6nCFACWMWE93WNcq+HBa025zsw=="
+  },
+  "25.0.13": {
+    "internalVersion": "25.0.13.2",
+    "signature": "FVPFITm49G4y0pv7xo9XWeLw4zKopsAwrj2iVSW2je9Nq2U25RpudHkrSwHZY2JDFsjx8xFncgjHT1iiuZJHBOkInfmJYvsBe3RVuS87uLhmeVevLKwBC+ZkgbRiMwX8j6TaNthAVOlYaowAQAjyRgJ8AAg3L5liYmqhobBUgtwd86wRlzk5Fy9MTAM3BSwnJ5CqVqcGxVBCJdTp73oryXSctu1lHS4zS4eMWaqSPrCDb4uSMyjE4DESH60dwVyRX6IrjOfLlNvurihALJuhJzqWG+Xdi3xurMOI65ad8im2+7tiB/yu5Bb5NdSl8KvLc2rOEZwqzv2p7fWh4Ovl6g=="
+  },
+  "26.0.13": {
+    "internalVersion": "26.0.13.1",
+    "signature": "bvGxFDuB+F5C9DqiARiF9MifdcZEQ2R5+AvgCEs/hnrUugRjTXMvJPRkaDLL01YfQoiNwNG3da/2JQEAfZ23YkQedNQ6T3fs7HGbhUZA3xFZb06kxQpLJFI/Ncei8i16+QyxhlQtOlhBG0ExG0M0LD3Ow9ZFsCkRk1Ja2YIRBW3mRUdnqew8mYYKltZJL444D5BO/0AisCh9hVI7JzExVmwYL/HOmbG5GBpy7BLJnSOUU0Di5PSfwoLIOqLsg/9+qVqpedb3ivvwVR1pZqTUyrUPDYojLnyw3XCSKb588U6kSNhaMj/Kl5/5KT34OG+2m04vBdfnV+VUhCBz0tYn9A=="
+  },
+  "27.1.11": {
+    "internalVersion": "27.1.11.3",
+    "signature": "brs2KkUu60QmFZD46rSTyg3qBSlYnv584xeFNWLl2ZM4cwItzJ5wXeajfrPvoUQJGWw7Ln4pQPHja4GrYaNfrKewbBzdJ295glFA5Biwk8OaacsAh6lZm4QH87OUjvgS560LH0hW99Jf9aFv/qqj56T0GSGlGS3qv/HNimmeC0sZfLNDdxjaDWBpVJkt+45ZvJJ8XVSDOlNNKjcgvcUMrsDItXioSwBst6vTdR5IKLAFivlb7HYLUN48R9h57QM2v8X/N49mF+Wk3PQa19wBVsUFYkaQuG9FTjUVgvp8bgv3s9rhrOLJa5KUOpdcodgZfaeql723PcZEzPJ3dzisSw=="
+  },
+  "28.0.14": {
+    "internalVersion": "28.0.14.1",
+    "signature": "e3wnEZE0ooyNX8CpsSEgXafLoOU/U+zORUyeqKczWuuf2Srq4edl2SCaQgvdSLsGDZo8h9LLEsh544/NyS8VOY7aJVqR2JOC4bUyztfNTnlppRLVTCIXx053Eht9+neNpYlPy8hBK+KBLoN7q3WYcWL1QOIrUAzgxhjwshMrTxNrHi8Nq7g37iZUzhPU5HWwMUID9gsQnT+aFurooLVvWMM8Ad0RkU72i5Y7I80c+v/2MYE9rxUmNC54noVePvrjR8zf/PC+Yj1vxFZ0hYAtweLgBxfwU5cNBYfH7M1I9FLlb88p/XDWx6XaBz4Ql6LKlbpDxNE9UiM09JG1dU7Ebg=="
+  },
+  "29.0.16": {
+    "internalVersion": "29.0.16.1",
+    "signature": "rouEEVNhNDWtZcK4LRDcYCZWS8zkSEWcjgJcbJOGnIHtH2GX4cxLR17gYpetSzfGGF2Dgv01dUXQw8FHI0ygaEOWYO+xz75WN5tuW3MsZ70u0xZF7bHejkv0YHHwyMjg6nei9Xn2FUTwmCpse6Lt6F5NUZD3Eq1ODrE3U1FKU6PB67tE7Q8kj13r7oJQ+SKwSO1Tn/u52YMmiGyzdmFK9zSRwa7BqkpgHVpVK+wjCkI/jk0ohUr8gcfS755BbflEDa0OcyJLoyz0qWyzsFAhSD7Y/Kbr8Y59wi77Z3jUUpV9IeHFmQy9OsqjyrRtIHtjyHoib4f8qGhnvNCT5Q/wOA=="
+  },
+  "30.0.17": {
+    "internalVersion": "30.0.17.2",
+    "signatures": {
+      "bz2": "Eazfs97Esa+8x4pAzvEq4zdsZnzTUGG05bdAUgPthbvg3ScgSs0J1FvlrZCL62kNXfA/oDAkVTcX7ub0J+C7+wPJp7sfL9awV03H/5365eME85eR+AM6sayTCruRuqkfNaWCqcbLyIC7StJngSiFbeE8vi+yG/6p42x/ZpFi0d8QoIP98DXsrMxQImVPsZtSoWdLkwgl+r/2Rh1pp98KI+fpj8Q2rRKE2o211yYPrRPfwMTn5v85yMqpcnfCKPcrUzSVnHaX3wGycE4TRS5T1AXB6ua74hHYNCeBBtDPrFEF2MuBC0Bwji/WjC6mCL94hlK0PeYrgZ7QR5juCzM8gA==",
+      "zip": "bKCHRPqnAOGlv1coBuKMbG2ndH+VoO4R6Gk7LXcRk9oLJ/LhewbMQtPsyVuc2dNeWFTBxxm1jNwXuKPiKLfX1J8ZVbAPA1hIPom3WSt5kpBO+xS+hZGS2I+IDh3tmVwbUyuloprC0iWBrQSPqNj0Ov6BK9iN+wiB+Wh1UIL7ln619CtJx3pj49QSFL0kMq4KXb/jm2i0Yqwh+XUJyG4Rz2UCkxeCgj6V3szC1fMNzZK1C1u/X+jA1j/OgyLxtmz98Ub1U8v3WDOeDwyzG+DjjXvu4hrm8zZyu6+11ytlQG9YPfiZ0momiAQBHo9OVlBsdP5deAwX1CeMH4+yk2kfng=="
+    }
+  },
+  "31.0.14": {
+    "internalVersion": "31.0.14.1",
+    "signatures": {
+      "bz2": "r/9cFMXfoPhbXuBDKvNr0ZqWY2wXsgFJwXTokeA7qhAs5Q/TTolxsYJlS5TQUKYS5CeFqtwRq8UsJ9LtpB0IMn9BsgZ+JcvvyhViNdX5owfDw7X25JCB6Xfq0zBK3n3++bZawQafGD7Y/JRGVe6GaMk+IGTHJjabpHtDtRCvQj2LdJ8kAkj7CKW8enfROjgst8FRm65iAs9wru22NdG18YK5/1pi1HYE+FnZgVSS4ywFzyCtqWdlYGLtifAo8Ok9KLcsskAkZCRYeJS/kY7HDfFfVvJaKHsHLKFSnSYU28xDp7QsPHBRKDZip7LrcpHt9sAJugBvNTxBojJVRwXREg==",
+      "zip": "oM4xe+KQxwzwGXq0JwYbt6xRsgu4Ejf9vrdNrNPZB/dnEDq/EWFLBJXoiq4Hfq+xIrJz+Cok4RjPg/NdNl/A+fWC47aJh+gPZUw0BITf8GZ/BeAzdlyxUG9+VrIMYEARr93DL16y1mCk7dkkMC/a8DT5/orqXnWIP38wgXzbU+DcyA9eCq28+aSz25MLYSHRedNnmki3ovqsa4K6/5D+RvcXXwn4/xnk5Dboi8akNSEnXfmTpTJs8D8HqAXBruklPA45206JcfSACC5ePc0ZfUPrV3ToKFlijsBdIsuNgpzmOIwukB4MUO+RLyk4lPOGZwCpfYewGDvrElT50aJYkA=="
+    }
+  },
+  "32.0.11": {
+    "internalVersion": "32.0.11.1",
+    "signatures": {
+      "bz2": "NGJLWSS5LG22tuRHNgIc1wXeX7L+NxCfW9p7bsGDJ2tPRbhSI95TMg09EWILZdg0n+XO+LAMzT3VPO/DtMLM8IOkhnAjT5cBlCdjF3alTAP7aZKA05vIgTxYq9J5HTSkvT3eolazQ8vXnDxkAEAGZpvHyXsIFKLMdyMtZNEYOvKiteRwnSyGR41v/5plgbRVuzKKT1ed9e9J1V8CKoJq/Yhaybt4jlSkaSCAA37iKwz0vECco6Jjnhts8l6cjRvxQSmoU7VtyXJAJbOU/EPT0L4PnZBJ6BkaxbtEJLyuAkqtMLWmyjWiFaVvJ803U9OLKj8h7Sxlq3dnZ2hAGKTB+Q==",
+      "zip": "fjrCxIdnySTTWKZifdp5+2SUF31Vv7d2JR0i8LL6O7NZ76xmKk8mQY44ecwNErUsUbbEFO/s0WUbFGgU4ZUvDaxjYlQYYXkUAD6PSl/UnN/RBIQJhi0haM5oOsa+90oeb65FFNyX4uGHjAWMNhv9ChZc5rmZgv35lmMLMJ2O4W+1xhLabppucMWEvwd2+EV2V/Iy9Qo5gZx82vCbZigpn6OQo011DiRY1Q4i2hlirZsp8Jk18CjAznZQ0s+1RxRfEWl89AtaAYE7NPBhMYb5hTsDzRVizVUU3YYTCWqEpd4DV8q4RywFN03K9oiJAAdZyvE6RPkGve7ePndOyln6mw=="
+    }
+  },
+  "33.0.5": {
+    "internalVersion": "33.0.5.1",
+    "signatures": {
+      "bz2": "ZVV1ugYQIUnV6DreCzY6MDSiqnH7QzAk/KaNSodG/cxVhqan20JCpFnxUuakBvL723H4gOaAzOtehrMTqNKxH+6vdk3Fri9Iv45t4M2uNIkWDrsviaqvrJN3zj43Wnx5G4SfEVa9WoKvhVDZUGWb3B2i3jiR7zbLf8kkXOIZfn/NJD3i/fnWC6wTxAl9zzFTDUuNQZO9CPX/u+AwYG6WL4MPlzSiHKUYqtWS7IYPPaK8ji4MxHVkz8phtG2P51r7zBvvvZ4m9RUd9NKHtj0pvEvv4eyhz9OF/JigjeGIYx3eIqgKhO2YQ1irk+CKiqHPmOPcSrbqMCEewD9BnNSiNg==",
+      "zip": "srq41voRX6MJhV4uKhKD63uZMYQ0OVrTfdC2aKEY6st/dVJtEa9Us5Gs8HCS0sJ0o5TzKh6vQ7ETyugEWoussxlLrdbsbkAj4D48zF4MOjhxVcsZd7SybTQkzVtd7JVCRr4RdAdARd9PAGJrTDWQlDi2SW+F0T9ZpZ44rlesWLWTH2OZlIsQLFGKzcuO21XiyDdkbvVmX9MdxwlFmxtlEpPliZNEVzJ0yBv9uH/je2WnRk8u2Evu5VS1I2iTfRoCp24a00mGWzUJJVD2hMVktzBecm0ffoI0Phe1SngOqljAo5r5LCiqKswtDjD2Cfd+Q36WWyhFw7is33ZSGoRW8w=="
+    }
+  },
+  "34.0.0": {
+    "internalVersion": "34.0.0.12",
+    "signatures": {
+      "bz2": "Xcmsalf2JFOERdm+glnMIgwKJP7cu3CK1Kt9doIIELl+0/W5nJp98ZDs29m445/eTZPhjOBDcu1xw/AblUNeU0eAyNQflMhtT82Zoe4eKiQ14/Oerh+M+/t7O3dmqbDwW+2QAteOHSeKcWb+m5KSWEWW81M+OiXPCauLnYVP6oG66Dn2Wqt6dOAjwLpn6z02uGWTZy+4C0Uok/kY+xtmsy/uiIiZvvuVZFdGGh9eKhinr8PbCyvON1pFmb0FjCi3Ybg2VWxS+M9hm9DErFQcEHuf2O8QRmWsUdTC8+Bghp0pMHYju8ftKcRowQkBu8c/7RQFy55zpZaPEo6+0weB/A==",
+      "zip": "wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1Rn+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5lqR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHvcnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZtROcuuq4A6jcCjhT178clw=="
+    },
+    "deploy": 30
+  }
 }

--- a/tests/integration/features/beta.feature
+++ b/tests/integration/features/beta.feature
@@ -759,22 +759,22 @@ Feature: Testing the update scenario of beta releases
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "34.0.0.11" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip"
-    And Download URLS contain "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip"
-    And Download URLS contain "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.tar.bz2"
-    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.zip"
-    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.tar.bz2"
+    And Update to version "34.0.0.12" is available
+    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2"
     And URL to documentation is "https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html"
     And EOL is set to "0"
     And The signature is
     """
-    ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1
-    /VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid
-    2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB
-    3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA
-    4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrIS
-    ILUlWHKNuhVMDCWn0BkbFw==
+    wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+    n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+    qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+    ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+    cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+    tROcuuq4A6jcCjhT178clw==
     """
 
   Scenario: Updating Nextcloud 34 on the beta channel
@@ -784,20 +784,20 @@ Feature: Testing the update scenario of beta releases
     And the installation mtime is "11"
     When The request is sent
     Then The response is non-empty
-    And Update to version "34.0.0.11" is available
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip"
-    And Download URLS contain "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip"
-    And Download URLS contain "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.tar.bz2"
-    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.zip"
-    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0rc5/nextcloud-34.0.0rc5.tar.bz2"
+    And Update to version "34.0.0.12" is available
+    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2"
     And URL to documentation is "https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html"
     And EOL is set to "0"
     And The signature is
     """
-    ASRN+8v3PuruzBxeeuNlwJnNjFYfl3Z6BRcD6HK8J5F6horerzVM6oW94AY05+s1
-    /VSHrcubkEHxg5146qr0W3QBgfJP5HwMtb7KhpnbopTdDFalUjlr6zIhlShGiHid
-    2hy8y+Kb9yLieeG7QzP6qsTaftx9JXFD7V7GFdFrs1sVJZx9VVjUCCkfDizfqcrB
-    3lpXUQe3ayXoF6Y740Ycz1BacuQsjuEAoKSVrCWnTQBfZX/sQwgr4DNE2G9v27VA
-    4QVguGILzho/zR1XPQCv+vKeFvYnjV4HRGocUA9Y0A9Y4vhMWelebN/wLZGvMrIS
-    ILUlWHKNuhVMDCWn0BkbFw==
+    wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+    n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+    qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+    ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+    cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+    tROcuuq4A6jcCjhT178clw==
     """

--- a/tests/integration/features/latest.feature
+++ b/tests/integration/features/latest.feature
@@ -4,15 +4,15 @@ Feature: Testing the latest endpoint
     Given I want to know the latest stable release
     When I send a request latest.php
     Then The JSON response is non-empty
-    And Version "33.0.5" is the latest release
-    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-33.0.5.zip"
+    And Version "34.0.0" is the latest release
+    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
 
   Scenario: Get latest beta version
     Given I want to know the latest beta release
     When I send a request latest.php
     Then The JSON response is non-empty
-    And Version "34.0.0 RC5" is the latest release
-    And URL to download is "https://download.nextcloud.com/server/prereleases/nextcloud-34.0.0rc5.zip"
+    And Version "34.0.0" is the latest release
+    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
 
   Scenario: Get latest stable version with PHP 8.0
     Given I want to know the latest stable release

--- a/tests/integration/features/stable.feature
+++ b/tests/integration/features/stable.feature
@@ -813,3 +813,61 @@ Scenario: Updating Nextcloud 32 on the stable channel
     p24a00mGWzUJJVD2hMVktzBecm0ffoI0Phe1SngOqljAo5r5LCiqKswtDjD2Cfd+
     Q36WWyhFw7is33ZSGoRW8w==
     """
+
+  Scenario: Not updating Nextcloud latest 33 to 34 on the stable channel (staged rollout)
+    Given There is a release with channel "stable"
+    And The received version is "33.0.5.1"
+    And The received PHP version is "8.2.0"
+    And the installation mtime is "41"
+    When The request is sent
+    Then The response is empty
+
+  Scenario: Updating Nextcloud latest 33 to 34 on the stable channel
+    Given There is a release with channel "stable"
+    And The received version is "33.0.5.1"
+    And The received PHP version is "8.2.0"
+    And the installation mtime is "11"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "34.0.0.12" is available
+    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2"
+    And URL to documentation is "https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html"
+    And EOL is set to "0"
+    And The signature is
+    """
+    wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+    n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+    qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+    ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+    cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+    tROcuuq4A6jcCjhT178clw==
+    """
+
+  Scenario: Updating Nextcloud 34 on the stable channel
+    Given There is a release with channel "stable"
+    And The received version is "34.0.0.0"
+    And The received PHP version is "8.2.0"
+    And the installation mtime is "11"
+    When The request is sent
+    Then The response is non-empty
+    And Update to version "34.0.0.12" is available
+    And URL to download is "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://download.nextcloud.com/server/releases/nextcloud-34.0.0.tar.bz2"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.zip"
+    And Download URLS contain "https://github.com/nextcloud-releases/server/releases/download/v34.0.0/nextcloud-34.0.0.tar.bz2"
+    And URL to documentation is "https://docs.nextcloud.com/server/34/admin_manual/maintenance/upgrade.html"
+    And EOL is set to "0"
+    And The signature is
+    """
+    wWen1mebrZlE/v3OT7QPuy0gG8pXZi6LpiGykQmU/d50jD1T1xhC5XjzBuavFw1R
+    n+f3hMDTLX6ZRpXCT8ETP4ahczcedWvJ8M0DDs5b7zJH4KCCNbQ+f087v6GbSY5l
+    qR/aHiW4ILSroY/4bTgSBSIlEZNfbMGOYdU28RcnwfYXK6GlYm7myunpgLQl0TO8
+    ncnZxYyOp1hlYEKCicBv9daqZLBzNlHPyMZRlQaFVy56julzKYuYrEOIYJ97MqHv
+    cnAiQW/rPKpjO9aEscca9al8N8HkRZ0xatUXzNibwoAI6kgFltgSGdxfaTYFN/yZ
+    tROcuuq4A6jcCjhT178clw==
+    """


### PR DESCRIPTION
## What

The `Upgrades` workflow fails for the job **"Upgrade from 34 to 34.0.0 (stable - updater/manual)"** whenever a new major's *first* stable release lands (seen on #1380).

## Why

`build/config_builder` always emits a bare-major entry, e.g. `'34' => ['100' => ['latest' => '34.0.0', …]]`. In `.github/workflows/upgrade.yml` the "Fetch release" step normalizes the base `34 → 34.0.0` and fetches `nextcloud-34.0.0.zip` — which is the **same version** as the target `latest`. The updater (and `occ upgrade`) rightly refuse a no-op same-version upgrade, so the job fails.

This only breaks at `X.0.0`. Any later patch (base `33 → 33.0.0`, target `33.0.5`) has base ≠ target and runs normally.

## How

Detect `base == target` right after the base release is fetched (compare the `occ status` version string against the matrix `latest` prefix — reusing the same prefix extraction the "Verify final" step already uses) and set a `SKIP_UPGRADE` env flag. The fetch/upgrade/integrity/verify steps are gated on it. Skipped steps leave the job `success`, so the existing `upgrades-summary` gate stays green; real upgrade entries are unaffected.
